### PR TITLE
handle retrying/restarting if websocket is unavailable or dropped

### DIFF
--- a/lib/iodized2_ruby_client/client.rb
+++ b/lib/iodized2_ruby_client/client.rb
@@ -8,14 +8,25 @@ module Iodized2RubyClient
 
     def_delegators :@features, :features, :enabled?
 
+    attr_reader :status
+
     def initialize(url, key, secret)
-      @url = url
       @features = FeaturesSet.new
 
-      @ws_client = Iodized2RubyClient::WSClient.new(@url, key, secret) do |message|
-        handle_message(message)
-      end
+      connect_web_socket(url, key, secret)
     end
+
+    def close
+      case status
+      when :connecting then @supervisor.kill
+      when :running then @ws_client.close
+      else
+        # nothing to do we are not in a state that needs cleanup
+      end
+      @status = :terminated
+    end
+
+    private
 
     def handle_message(message)
       puts message
@@ -25,7 +36,6 @@ module Iodized2RubyClient
       send("handle_#{key}", result[key])
     end
 
-    private
 
     def handle_sync(features)
       @features.sync_features(features)
@@ -41,6 +51,33 @@ module Iodized2RubyClient
 
     def handle_delete(feature)
       @features.delete_feature(feature)
+    end
+
+    def connect_web_socket(url, key, secret)
+      @status = :connecting
+      @supervisor = Thread.new do
+        backoff = nil
+        begin
+          sleep(backoff / 100.0) if backoff
+          @ws_client = Iodized2RubyClient::WSClient.new(url, key, secret) do |message|
+            handle_message(message)
+          end
+          @status = :running
+          backoff = nil
+          @ws_client.join
+          puts "ws_client ended...what now?"
+          @status = :terminated if @ws_client.status == :closed
+        rescue Errno::ECONNREFUSED => e
+          puts e
+          backoff ||= 1
+          backoff <<= 1
+          puts "Backoff is now #{backoff / 100.0} seconds"
+          next
+        rescue => e
+          @status = :failed
+          @error = e
+        end while ![:terminated, :failed].include?(@status)
+      end
     end
   end
 end

--- a/test/iodized2_ruby_client_test.rb
+++ b/test/iodized2_ruby_client_test.rb
@@ -5,7 +5,15 @@ class Iodized2RubyClientTest < Minitest::Test
     refute_nil ::Iodized2RubyClient::VERSION
   end
 
-  def test_it_does_something_useful
-    assert false
+  def test_no_connection_does_not_fail_client_creation
+    client = ::Iodized2RubyClient.new("ws://localhost:9999/whatever-it-won't-work", "key", "secret") do |_message|
+      fail "We shouldn't receive a message!"
+    end
+    assert client.status == :connecting
+
+    sleep(10)
+    client.close
+
+    assert client.status == :terminated
   end
 end


### PR DESCRIPTION
A bit of a "seat of the pants" supervisor to manage the client in the face of the server not being there at startup or if it goes down.

* exponential backoff (no jitter)
  * and never gives up (but can be killed by the owner of the client instance)
* this seems to work
* there may be some finer points that are not well implemented
* I've tested this locally by starting/stopping iodized multiple times.
