### PR TITLE
Upgrade Rake to v13

### DIFF
--- a/iodized2_ruby_client.gemspec
+++ b/iodized2_ruby_client.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faye-websocket"
 
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 end


### PR DESCRIPTION
This resolves the security alert for [CVE-2020-8130](https://github.com/advisories/GHSA-jppv-gw3r-w3q8).